### PR TITLE
build(deps): bump the crates group across 1 directory with 39 updates

### DIFF
--- a/manager/app/src/main/res/values-ar/strings.xml
+++ b/manager/app/src/main/res/values-ar/strings.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="issue_report_title">تواجه مشكلة؟</string>
+    <string name="issue_report_body">حصل خطأ ما او لديك تعليقات؟</string>
+    <string name="issue_report_body_2">بلغنا بها على الفور!</string>
+    <string name="issue_report_github">ابلغنا عن طريق Github</string>
+    <string name="issue_report_telegram">تواصل من خلال التليجرام</string>
+    <string name="issue_report_github_link">https://github.com/KernelSU-Next/KernelSU-Next/issues</string>
+    <string name="issue_report_telegram_link">https://t.me/ksunext</string>
+    <string name="confirm">تأكيد</string>
+    <string name="app_name" translatable="false">KernelSU Next</string>
+    <string name="home">الصفحة الرئيسية</string>
+    <string name="home_not_installed">غير مثبت</string>
+    <string name="home_click_to_install">انقر للتثبيت</string>
+    <string name="home_working">يعمل</string>
+    <string name="home_working_version">الإصدار: %d</string>
+    <string name="home_superuser_count">عدد التطبيقات ذات صلاحيات الروت: %d</string>
+    <string name="home_module_count">عدد الإضافات: %d</string>
+    <string name="home_failure">توقيع KSU Next v2 غير موجود [ !KSU_NEXT || != size/hash ]</string>
+    <string name="home_failure_tip">اطلب من مطور بتهيئة KSU Next لجهازك</string>
+    <string name="home_kernel">اصدار Kernel</string>
+    <string name="enabled">مفعل</string>
+    <string name="disabled">معطل</string>
+    <string name="susfs_supported">مدعوم</string>
+    <string name="home_susfs">SuSFS: %s</string>
+    <string name="home_susfs_version">اصدار SuSFS</string>
+    <string name="home_susfs_sus_su">SuS SU</string>
+    <string name="home_android">إصدار الأندرويد</string>
+    <string name="home_manager_version">اصدار مدير الروت</string>
+    <string name="home_selinux_status">حالة SELinux</string>
+    <string name="selinux_status_disabled">معطل</string>
+    <string name="selinux_status_enforcing">مفعل</string>
+    <string name="selinux_status_permissive">مرن</string>
+    <string name="selinux_status_unknown">غير معروف</string>
+    <string name="superuser">مستخدم خارق</string>
+    <string name="module_failed_to_enable">فشل في تشغيل إضافة: %s</string>
+    <string name="module_failed_to_disable">فشل في إيقاف إضافة: %s</string>
+    <string name="module_empty">لا توجد إضافات مثبته</string>
+    <string name="module">الإضافة</string>
+    <string name="module_install_prompt_with_name">الإضافة/ات التالية سيتم تثبيتها: %1$s</string>
+    <string name="module_sort_a_to_z">تصنيف (أ-ي)</string>
+    <string name="module_sort_z_to_a">تصنيف (ي-أ)</string>
+    <string name="uninstall">إلغاء التثبيت</string>
+    <string name="restore">إستعادة</string>
+    <string name="module_install">تثبيت</string>
+    <string name="install">تثبيت</string>
+    <string name="reboot">إعادة تشغيل</string>
+    <string name="settings">الإعدادات</string>
+    <string name="reboot_userspace">إعادة تشغيل سريعة</string>
+    <string name="reboot_recovery">إعادة التشغيل إلى وضع الريكفري</string>
+    <string name="reboot_bootloader">إعادة التشغيل إلى وضع bootloader</string>
+    <string name="reboot_download">إعادة التشغيل إلى وضع التحميل</string>
+    <string name="reboot_edl">إعادة التشغيل إلى وضع EDL</string>
+    <string name="about">حول</string>
+    <string name="module_uninstall_confirm">هل انت متأكد من حذف تلك الإضافة %s؟</string>
+    <string name="module_uninstall_success">%s تم إلغاء تثبيت</string>
+    <string name="module_uninstall_failed">فشل في إلغاء تثبيت: %s</string>
+    <string name="module_restore_confirm">هل انت متأكد من استرجاع الإضافة؟ %s؟</string>
+    <string name="module_restore_success">%s تم استعادة</string>
+    <string name="module_restore_failed">فشل استعادة: %s</string>
+    <string name="module_version">الإصدار</string>
+    <string name="module_author">المطور</string>
+    <string name="module_id">ID</string>
+    <string name="module_version_code">كود الإصدار</string>
+    <string name="module_update_json">UpdateJson</string>
+    <string name="module_update_json_empty">فارغ</string>
+    <string name="enable_developer_options">تفعيل خيارات المطور</string>
+    <string name="enable_developer_options_summary">عرض الإعدادات المخفية ومعلومات التصحيح ذات الصلة فقط للمطورين.</string>
+    <string name="module_overlay_fs_not_available">الإضافات غير متاحة حيث أن OverlayFS معطلة بواسطة النواة.</string>
+    <string name="refresh">تحديث</string>
+    <string name="show_system_apps">عرض تطبيقات النظام</string>
+    <string name="hide_system_apps">إخفاء تطبيقات النظام</string>
+    <string name="export_log">تصدير السجلات</string>
+    <string name="safe_mode">وضع الأمان</string>
+    <string name="reboot_to_apply">إعادة التشغيل لتطبيق التغييرات</string>
+    <string name="module_magisk_conflict">الإضافات غير متاحة بسبب تعارض مع Magisk!</string>
+    <string name="home_module_mount">نظام الإضافات</string>
+    <string name="home_magic_mount">Mount السحري</string>
+    <string name="home_overlayfs_mount">OverlayFS</string>
+    <string name="unavailable">غير متاح</string>
+    <string name="use_overlay_fs">استخدام OverlayFS</string>
+    <string name="use_overlay_fs_summary">التبديل بين استخدام OverlayFS أو Mount السحري لنظام Mount الخاص بـ KernelSU Next.</string>
+    <string name="reboot_required">إعادة التشغيل مطلوبة</string>
+    <string name="reboot_message">ستدخل التغييرات حيز التنفيذ بعد إعادة تشغيل النظام. هل تريد إعادة التشغيل الآن؟</string>
+    <string name="module_restore">استعادة الإضافة</string>
+    <string name="module_restore_message">استعادة الإضافات من النسخة الاحتياطية الأخيرة.</string>
+    <string name="backup_restore">نسخ احتياطي واستعادة</string>
+    <string name="module_backup">نسخ احتياطي للإضافة</string>
+    <string name="module_backup_message">نسخ احتياطي للإضافات المثبتة حاليًا.</string>
+    <string name="allowlist_restore">استعادة القائمة المسموح بها</string>
+    <string name="allowlist_restore_message">استعادة القائمة المسموح بها من النسخة الاحتياطية الأخيرة.</string>
+    <string name="allowlist_backup">نسخ احتياطي للقائمة المسموح بها</string>
+    <string name="allowlist_backup_message">نسخ احتياطي للقائمة المسموح بها المكونة حاليًا.</string>
+    <string name="warning">تحذير</string>
+    <string name="warning_message">هذه الميزة لا تزال في مرحلة البيتا وتحت التطوير. يرجى التأكد من عمل نسخة احتياطية من الإضافات الخاصة بك قبل المتابعة. استخدم هذه الميزة فقط إذا كنت تفهم المخاطر المحتملة. أكمل بحذر.</string>
+    <string name="proceed">تابع</string>
+    <string name="cancel">إلغاء</string>
+    <string name="later">لاحقًا</string>
+    <string name="home_next_kernelsu">🔥 الإصدار التالي</string>
+    <string name="home_next_kernelsu_repo">https://github.com/KernelSU-Next/KernelSU-Next</string>
+    <string name="home_next_kernelsu_body">فرع تجريبي قادم. تحقق منه على GitHub!</string>
+    <string name="home_experimental_kernelsu">⚠️ تجريبي!</string>
+    <string name="home_experimental_kernelsu_repo">127.0.0.1</string>
+    <string name="home_experimental_kernelsu_body">KernelSU Next هو إصدار غير رسمي دائمًا تحت التطوير التجريبي النشط. يتم تقديمه كما هو، دون ضمانات للاستقرار أو الأداء أو الموثوقية.</string>
+    <string name="home_experimental_kernelsu_body_point_1"> • استخدم على مسؤوليتك: قد تحدث أعطال أو سلوك غير متوقع أو مشاكل في النظام.</string>
+    <string name="home_experimental_kernelsu_body_point_2"> • لا ضمان: المطورون غير مسؤولين عن أي فقدان للبيانات أو تلف النظام أو عواقب أخرى ناتجة عن استخدامه.</string>
+    <string name="home_experimental_kernelsu_body_point_3"> • لأغراض الاختبار فقط: مخصص للمستخدمين الذين يفهمون المخاطر ويشعرون بالراحة في حل المشكلات.</string>
+    <string name="about_source_code"><![CDATA[عرض الشيفرة المصدرية في %1$s]]></string>
+    <string name="profile" translatable="false">ملف التطبيق</string>
+    <string name="profile_default">افتراضي</string>
+    <string name="profile_template">قالب</string>
+    <string name="profile_custom">مخصص</string>
+    <string name="profile_name">اسم الملف الشخصي</string>
+    <string name="profile_namespace">مساحة التثبيت</string>
+    <string name="profile_namespace_inherited">موروث</string>
+    <string name="profile_namespace_global">عالمي</string>
+    <string name="profile_namespace_individual">فردي</string>
+    <string name="profile_groups">المجموعات</string>
+    <string name="profile_capabilities">القدرات</string>
+    <string name="profile_selinux_context">سياق SELinux</string>
+    <string name="profile_umount_modules">إلغاء تثبيت الإضافات</string>
+    <string name="failed_to_update_app_profile">فشل في تحديث ملف التطبيق لـ %s</string>
+    <string name="require_kernel_version">إصدار KernelSU Next الحالي %1$d منخفض جدًا لكي يعمل المدير بشكل صحيح. يرجى الترقية إلى الإصدار %2$d أو أعلى!</string>
+    <string name="settings_umount_modules_default">إلغاء تثبيت الإضافات</string>
+    <string name="settings_umount_modules_default_summary">القيمة الافتراضية العالمية لـ "إلغاء تثبيت الإضافات" في ملف التطبيق. إذا تم تفعيلها، ستقوم بإزالة جميع التعديلات التي أجرتها الإضافات على النظام للتطبيقات التي لا تحتوي على ملف شخصي محدد.</string>
+    <string name="settings_susfs_toggle">إخفاء خطافات kprobe</string>
+    <string name="settings_susfs_toggle_summary">تعطيل خطافات kprobe التي أنشأها ksu، وبدلاً من ذلك، تفعيل الخطافات غير الكروب المدمجة، مما ينفذ نفس الوظائف التي ستطبق على نواة غير GKI، والتي لا تدعم kprobe.</string>
+    <string name="profile_umount_modules_summary">تفعيل هذا الخيار سيسمح لـ KernelSU Next باستعادة أي ملفات معدلة بواسطة الإضافات لهذا التطبيق.</string>
+    <string name="profile_selinux_domain">النطاق</string>
+    <string name="profile_selinux_rules">القواعد</string>
+    <string name="module_update">تحديث</string>
+    <string name="module_downloading">جارٍ تنزيل الإضافة: %s</string>
+    <string name="module_start_downloading">بدء التنزيل: %s</string>
+    <string name="new_version_available">إصدار جديد %s متاح، انقر للتحديث.</string>
+    <string name="launch_app">تشغيل</string>
+    <string name="close">إغلاق</string>
+    <string name="force_stop_app">إيقاف إجباري</string>
+    <string name="restart_app">إعادة تشغيل</string>
+    <string name="failed_to_update_sepolicy">فشل في تحديث قواعد SELinux لـ: %s</string>
+    <string name="su_not_allowed">لا يُسمح بمنح صلاحيات المستخدم الخارق لـ: %s</string>
+    <string name="module_changelog">سجل التغييرات</string>
+    <string name="settings_profile_template">قالب ملف التطبيق</string>
+    <string name="settings_profile_template_summary">إدارة القالب المحلي وعبر الإنترنت لملف التطبيق</string>
+    <string name="app_profile_template_create">إنشاء قالب</string>
+    <string name="app_profile_template_edit">تحرير القالب</string>
+    <string name="app_profile_template_id">ID</string>
+    <string name="app_profile_template_id_invalid">معرف القالب غير صالح</string>
+    <string name="app_profile_template_name">الاسم</string>
+    <string name="app_profile_template_description">الوصف</string>
+    <string name="app_profile_template_save">حفظ</string>
+    <string name="app_profile_template_delete">حذف</string>
+    <string name="app_profile_template_view">عرض القالب</string>
+    <string name="app_profile_template_readonly">للقراءة فقط</string>
+    <string name="app_profile_template_id_exist">معرف القالب موجود بالفعل!</string>
+    <string name="app_profile_import_export">استيراد/تصدير</string>
+    <string name="app_profile_import_from_clipboard">استيراد من الحافظة</string>
+    <string name="app_profile_export_to_clipboard">تصدير إلى الحافظة</string>
+    <string name="app_profile_template_export_empty">لا يمكن العثور على قالب محلي للتصدير!</string>
+    <string name="app_profile_template_import_success">تم الاستيراد بنجاح</string>
+    <string name="app_profile_template_sync">مزامنة القوالب عبر الإنترنت</string>
+    <string name="app_profile_template_save_failed">فشل في حفظ القالب</string>
+    <string name="app_profile_template_import_empty">الحافظة فارغة!</string>
+    <string name="module_changelog_failed">فشل في جلب سجل التغييرات: %s</string>
+    <string name="settings_check_update">التحقق من التحديث</string>
+    <string name="settings_check_update_summary">التحقق تلقائيًا من التحديثات عند فتح التطبيق.</string>
+    <string name="grant_root_failed">فشل في منح صلاحيات الجذر!</string>
+    <string name="action">إجراء</string>
+    <string name="open">فتح</string>
+    <string name="enable_web_debugging">تفعيل تصحيح WebView</string>
+    <string name="enable_web_debugging_summary">يمكن استخدامه لتصحيح WebUI. يرجى التفعيل فقط عند الحاجة.</string>
+    <string name="direct_install">التثبيت المباشر (موصى به)</string>
+    <string name="select_file">اختر ملفًا</string>
+    <string name="install_inactive_slot">التثبيت في الفتحة غير النشطة (بعد OTA)</string>
+    <string name="install_inactive_slot_warning">سيتم إجبار جهازك على الإقلاع إلى الفتحة غير النشطة الحالية بعد إعادة التشغيل!\nاستخدم هذا الخيار فقط بعد الانتهاء من OTA.\nهل تريد المتابعة؟</string>
+    <string name="install_next">التالي</string>
+    <string name="select_file_tip">%1$s Partition موصى به</string>
+    <string name="select_kmi">اختر KMI</string>
+    <string name="shrink_sparse_image">تقليل حجم partition المتناثرة</string>
+    <string name="shrink_sparse_image_message">إعادة حجم partition حيث توجد الإضافة إلى حجمها الفعلي. لاحظ أن هذا قد يتسبب في عمل الإضافة بشكل غير طبيعي، لذا يرجى استخدامه فقط عند الضرورة (مثل النسخ الاحتياطي).</string>
+    <string name="settings_uninstall">إلغاء التثبيت</string>
+    <string name="settings_uninstall_temporary">إلغاء التثبيت مؤقتًا</string>
+    <string name="settings_uninstall_permanent">إلغاء التثبيت نهائيًا</string>
+    <string name="settings_restore_stock_image">استعادة الصورة الأصلية</string>
+    <string name="settings_uninstall_temporary_message">إلغاء تثبيت KernelSU Next مؤقتًا، استعادة الحالة الأصلية بعد إعادة التشغيل التالية.</string>
+    <string name="settings_uninstall_permanent_message">إلغاء تثبيت KernelSU Next (الجذر وجميع الإضافات) بالكامل ودائمًا.</string>
+    <string name="settings_restore_stock_image_message">استعادة الصورة الأصلية (إذا كانت النسخة الاحتياطية موجودة)، عادة ما تستخدم قبل OTA؛ إذا كنت بحاجة إلى إلغاء تثبيت KernelSU Next، يرجى استخدام "إلغاء التثبيت نهائيًا".</string>
+    <string name="flashing">تثبيت</string>
+    <string name="flash_success">نجح التثبيت</string>
+    <string name="flash_failed">فشل التثبيت</string>
+    <string name="selected_lkm">LKM المحدد: %s</string>
+    <string name="save_log">حفظ السجلات</string>
+    <string name="log_saved">تم حفظ السجلات</string>
+    <string name="send_log">مشاركة السجلات</string>
+    <string name="settings_disable_su">تعطيل توافق su</string>
+    <string name="settings_disable_su_summary">تعطيل مؤقت لقدرة أي تطبيق على الحصول على صلاحيات الجذر عبر أمر ⁠su (لن تتأثر العمليات الجذرية الحالية).</string>
+    <string name="settings_language">اللغة</string>
+</resources>

--- a/userspace/ksud_magic/Cargo.lock
+++ b/userspace/ksud_magic/Cargo.lock
@@ -55,15 +55,15 @@ checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_log-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
 
 [[package]]
 name = "android_logger"
-version = "0.14.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b07e8e73d720a1f2e4b6014766e6039fd2e96a4fa44e2a78d0e1fa2ff49826"
+checksum = "f6f39be698127218cca460cb624878c9aa4e2b47dba3b277963d2bf00bad263b"
 dependencies = [
  "android_log-sys",
  "env_filter",
@@ -131,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "arbitrary"
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -211,15 +211,15 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "shlex",
 ]
@@ -232,23 +232,23 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
 dependencies = [
  "anstream",
  "anstyle",
@@ -268,9 +268,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -438,9 +438,9 @@ checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
 ]
@@ -478,21 +478,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -520,9 +509,9 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
 dependencies = [
  "env_filter",
  "log",
@@ -613,14 +602,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
+ "r-efi",
  "wasi",
- "windows-targets",
 ]
 
 [[package]]
@@ -668,14 +657,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -714,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -739,9 +729,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "java-properties"
@@ -817,9 +807,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libflate"
@@ -858,6 +848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+
+[[package]]
 name = "lockfree-object-pool"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,9 +861,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "loopdev"
@@ -886,6 +882,17 @@ checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
 dependencies = [
  "byteorder",
  "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -938,15 +945,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "powerfmt"
@@ -956,9 +969,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -990,12 +1003,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rayon"
@@ -1031,9 +1050,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rust-embed"
-version = "8.5.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
+checksum = "0b3aba5104622db5c9fc61098de54708feb732e7763d7faa2fa625899f00bf6f"
 dependencies = [
  "include-flate",
  "rust-embed-impl",
@@ -1043,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.5.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
+checksum = "1f198c73be048d2c5aa8e12f7960ad08443e56fd39cc26336719fdb4ea0ebaae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1056,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.5.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
+checksum = "5a2fcdc9f40c8dc2922842ca9add611ad19f332227fc651d015881ad1552bd9a"
 dependencies = [
  "sha2",
  "walkdir",
@@ -1079,7 +1098,7 @@ dependencies = [
  "errno 0.3.10",
  "itoa",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "once_cell",
  "windows-sys 0.52.0",
 ]
@@ -1093,21 +1112,34 @@ dependencies = [
  "bitflags 2.8.0",
  "errno 0.3.10",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags 2.8.0",
+ "errno 0.3.10",
+ "libc",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1120,18 +1152,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1140,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1174,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "sha256"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18278f6a914fa3070aa316493f7d2ddfb9ac86ebc06fa3b83bffda487e9065b0"
+checksum = "f880fc8562bdeb709793f00eb42a2ad0e672c4f883bbe59122b926eca935c8f6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1205,9 +1237,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1216,43 +1248,22 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 0.38.44",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "thiserror"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1263,15 +1274,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1286,9 +1297,9 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-width"
@@ -1326,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -1444,6 +1455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,11 +1550,20 @@ checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.8.0",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
 ]
 
 [[package]]
@@ -1562,21 +1588,20 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.2.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
+checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
  "deflate64",
- "displaydoc",
  "flate2",
  "indexmap",
  "lzma-rs",
  "memchr",
- "thiserror",
  "time",
+ "xz2",
  "zopfli",
 ]
 

--- a/userspace/ksud_magic/Cargo.toml
+++ b/userspace/ksud_magic/Cargo.toml
@@ -51,7 +51,7 @@ procfs = "0.17"
 loopdev = { git = "https://github.com/Kernel-SU/loopdev" }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = { version = "0.14", default-features = false }
+android_logger = { version = "0.15", default-features = false }
 
 [profile.release]
 strip = true

--- a/userspace/ksud_magic/src/sepolicy.rs
+++ b/userspace/ksud_magic/src/sepolicy.rs
@@ -1,11 +1,11 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use derive_new::new;
 use nom::{
+    AsChar, IResult, Parser,
     branch::alt,
-    bytes::complete::{tag, take_while, take_while1, take_while_m_n},
+    bytes::complete::{tag, take_while, take_while_m_n, take_while1},
     character::complete::{space0, space1},
     combinator::map,
-    AsChar, IResult, Parser,
 };
 use std::{ffi, path::Path, vec};
 

--- a/userspace/ksud_magic/src/utils.rs
+++ b/userspace/ksud_magic/src/utils.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Error, Ok, Result, bail};
 use std::{
-    fs::{create_dir_all, remove_file, write, File, OpenOptions},
+    fs::{File, OpenOptions, create_dir_all, remove_file, write},
     io::{
         ErrorKind::{AlreadyExists, NotFound},
         Write,

--- a/userspace/ksud_overlayfs/src/module.rs
+++ b/userspace/ksud_overlayfs/src/module.rs
@@ -12,8 +12,8 @@ use is_executable::is_executable;
 use java_properties::PropertiesIter;
 use log::{info, warn};
 
-use std::fs::OpenOptions;
 use std::fs;
+use std::fs::OpenOptions;
 use std::io;
 use std::{
     collections::HashMap,
@@ -381,26 +381,25 @@ fn _install_module(zip: &str) -> Result<()> {
     fn parse_size(size_str: &str) -> io::Result<u64> {
         let size_str = size_str.trim();
         if size_str.is_empty() {
-            return Err(io::Error::new(io::ErrorKind::InvalidData, "Empty size string"));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Empty size string",
+            ));
         }
-    
         let (num, unit) = size_str.split_at(size_str.len().saturating_sub(1));
-        let num = u64::from_str(num.trim()).map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid number"))?;
-    
+        let num = u64::from_str(num.trim())
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Invalid number"))?;
         let multiplier = match unit.to_ascii_uppercase().as_str() {
             "G" => 1 << 30,
             "M" => 1 << 20,
             "K" => 1 << 10,
             _ => 1, // Default to bytes if no unit is specified
         };
-    
         Ok(num * multiplier)
     }
-    
     fn get_sparse_image_size() -> u64 {
         let default_size = 6 << 30; // 6GB
         let custom_size_file = "/data/adb/ksu/custom_sparse_size.txt";
-    
         match fs::read_to_string(custom_size_file) {
             Ok(contents) => match parse_size(&contents) {
                 Ok(size) => size,


### PR DESCRIPTION
Bumps the crates group with 30 updates in the /userspace/ksud_magic directory:

| Package | From | To |
| --- | --- | --- |
| [anyhow](https://github.com/dtolnay/anyhow) | `1.0.96` | `1.0.97` | | [clap](https://github.com/clap-rs/clap) | `4.5.30` | `4.5.32` | | [zip](https://github.com/zip-rs/zip2) | `2.2.2` | `2.5.0` | | [log](https://github.com/rust-lang/log) | `0.4.26` | `0.4.27` | | [env_logger](https://github.com/rust-cli/env_logger) | `0.11.6` | `0.11.7` | | [serde_json](https://github.com/serde-rs/json) | `1.0.139` | `1.0.140` | | [libc](https://github.com/rust-lang/libc) | `0.2.170` | `0.2.171` | | [rust-embed](https://github.com/pyros2097/rust-embed) | `8.5.0` | `8.6.0` | | [sha256](https://github.com/baoyachi/sha256-rs) | `1.5.0` | `1.6.0` | | [tempfile](https://github.com/Stebalien/tempfile) | `3.17.1` | `3.19.1` | | [chrono](https://github.com/chronotope/chrono) | `0.4.39` | `0.4.40` | | [android_logger](https://github.com/rust-mobile/android_logger-rs) | `0.14.1` | `0.15.0` | | [async-trait](https://github.com/dtolnay/async-trait) | `0.1.86` | `0.1.88` | | [bytes](https://github.com/tokio-rs/bytes) | `1.10.0` | `1.10.1` | | [cc](https://github.com/rust-lang/cc-rs) | `1.2.15` | `1.2.17` | | [either](https://github.com/rayon-rs/either) | `1.14.0` | `1.15.0` | | [getrandom](https://github.com/rust-random/getrandom) | `0.3.1` | `0.3.2` | | [iana-time-zone](https://github.com/strawlab/iana-time-zone) | `0.1.61` | `0.1.62` | | [indexmap](https://github.com/indexmap-rs/indexmap) | `2.7.1` | `2.8.0` | | [itoa](https://github.com/dtolnay/itoa) | `1.0.14` | `1.0.15` | | [once_cell](https://github.com/matklad/once_cell) | `1.20.3` | `1.21.1` | | [proc-macro2](https://github.com/dtolnay/proc-macro2) | `1.0.93` | `1.0.94` | | [quote](https://github.com/dtolnay/quote) | `1.0.38` | `1.0.40` | | [rustversion](https://github.com/dtolnay/rustversion) | `1.0.19` | `1.0.20` | | [ryu](https://github.com/dtolnay/ryu) | `1.0.19` | `1.0.20` | | [serde](https://github.com/serde-rs/serde) | `1.0.218` | `1.0.219` | | [syn](https://github.com/dtolnay/syn) | `2.0.98` | `2.0.100` | | [time](https://github.com/time-rs/time) | `0.3.37` | `0.3.41` | | [tokio](https://github.com/tokio-rs/tokio) | `1.43.0` | `1.44.1` | | [unicode-ident](https://github.com/dtolnay/unicode-ident) | `1.0.17` | `1.0.18` |



Updates `anyhow` from 1.0.96 to 1.0.97
- [Release notes](https://github.com/dtolnay/anyhow/releases)
- [Commits](https://github.com/dtolnay/anyhow/compare/1.0.96...1.0.97)

Updates `clap` from 4.5.30 to 4.5.32
- [Release notes](https://github.com/clap-rs/clap/releases)
- [Changelog](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md)
- [Commits](https://github.com/clap-rs/clap/compare/clap_complete-v4.5.30...clap_complete-v4.5.32)

Updates `zip` from 2.2.2 to 2.5.0
- [Release notes](https://github.com/zip-rs/zip2/releases)
- [Changelog](https://github.com/zip-rs/zip2/blob/master/CHANGELOG.md)
- [Commits](https://github.com/zip-rs/zip2/compare/v2.2.2...v2.5.0)

Updates `log` from 0.4.26 to 0.4.27
- [Release notes](https://github.com/rust-lang/log/releases)
- [Changelog](https://github.com/rust-lang/log/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rust-lang/log/compare/0.4.26...0.4.27)

Updates `env_logger` from 0.11.6 to 0.11.7
- [Release notes](https://github.com/rust-cli/env_logger/releases)
- [Changelog](https://github.com/rust-cli/env_logger/blob/main/CHANGELOG.md)
- [Commits](https://github.com/rust-cli/env_logger/compare/v0.11.6...v0.11.7)

Updates `serde_json` from 1.0.139 to 1.0.140
- [Release notes](https://github.com/serde-rs/json/releases)
- [Commits](https://github.com/serde-rs/json/compare/v1.0.139...v1.0.140)

Updates `libc` from 0.2.170 to 0.2.171
- [Release notes](https://github.com/rust-lang/libc/releases)
- [Changelog](https://github.com/rust-lang/libc/blob/0.2.171/CHANGELOG.md)
- [Commits](https://github.com/rust-lang/libc/compare/0.2.170...0.2.171)

Updates `rust-embed` from 8.5.0 to 8.6.0
- [Changelog](https://github.com/pyrossh/rust-embed/blob/master/changelog.md)
- [Commits](https://github.com/pyros2097/rust-embed/commits)

Updates `sha256` from 1.5.0 to 1.6.0
- [Release notes](https://github.com/baoyachi/sha256-rs/releases)
- [Commits](https://github.com/baoyachi/sha256-rs/compare/1.5.0...1.6.0)

Updates `tempfile` from 3.17.1 to 3.19.1
- [Changelog](https://github.com/Stebalien/tempfile/blob/master/CHANGELOG.md)
- [Commits](https://github.com/Stebalien/tempfile/compare/v3.17.1...v3.19.1)

Updates `chrono` from 0.4.39 to 0.4.40
- [Release notes](https://github.com/chronotope/chrono/releases)
- [Changelog](https://github.com/chronotope/chrono/blob/main/CHANGELOG.md)
- [Commits](https://github.com/chronotope/chrono/compare/v0.4.39...v0.4.40)

Updates `android_logger` from 0.14.1 to 0.15.0
- [Release notes](https://github.com/rust-mobile/android_logger-rs/releases)
- [Changelog](https://github.com/rust-mobile/android_logger-rs/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rust-mobile/android_logger-rs/compare/0.14.1...v0.15.0)

Updates `android_log-sys` from 0.3.1 to 0.3.2
- [Commits](https://github.com/rust-mobile/android_log-sys-rs/commits)

Updates `async-trait` from 0.1.86 to 0.1.88
- [Release notes](https://github.com/dtolnay/async-trait/releases)
- [Commits](https://github.com/dtolnay/async-trait/compare/0.1.86...0.1.88)

Updates `bytes` from 1.10.0 to 1.10.1
- [Release notes](https://github.com/tokio-rs/bytes/releases)
- [Changelog](https://github.com/tokio-rs/bytes/blob/master/CHANGELOG.md)
- [Commits](https://github.com/tokio-rs/bytes/compare/v1.10.0...v1.10.1)

Updates `cc` from 1.2.15 to 1.2.17
- [Release notes](https://github.com/rust-lang/cc-rs/releases)
- [Changelog](https://github.com/rust-lang/cc-rs/blob/main/CHANGELOG.md)
- [Commits](https://github.com/rust-lang/cc-rs/compare/cc-v1.2.15...cc-v1.2.17)

Updates `clap_builder` from 4.5.30 to 4.5.32
- [Release notes](https://github.com/clap-rs/clap/releases)
- [Changelog](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md)
- [Commits](https://github.com/clap-rs/clap/compare/v4.5.30...v4.5.32)

Updates `clap_derive` from 4.5.28 to 4.5.32
- [Release notes](https://github.com/clap-rs/clap/releases)
- [Changelog](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md)
- [Commits](https://github.com/clap-rs/clap/compare/v4.5.28...v4.5.32)

Updates `either` from 1.14.0 to 1.15.0
- [Commits](https://github.com/rayon-rs/either/compare/1.14.0...1.15.0)

Updates `getrandom` from 0.3.1 to 0.3.2
- [Changelog](https://github.com/rust-random/getrandom/blob/master/CHANGELOG.md)
- [Commits](https://github.com/rust-random/getrandom/compare/v0.3.1...v0.3.2)

Updates `iana-time-zone` from 0.1.61 to 0.1.62
- [Changelog](https://github.com/strawlab/iana-time-zone/blob/main/CHANGELOG.md)
- [Commits](https://github.com/strawlab/iana-time-zone/compare/v0.1.61...v0.1.62)

Updates `indexmap` from 2.7.1 to 2.8.0
- [Changelog](https://github.com/indexmap-rs/indexmap/blob/main/RELEASES.md)
- [Commits](https://github.com/indexmap-rs/indexmap/compare/2.7.1...2.8.0)

Updates `itoa` from 1.0.14 to 1.0.15
- [Release notes](https://github.com/dtolnay/itoa/releases)
- [Commits](https://github.com/dtolnay/itoa/compare/1.0.14...1.0.15)

Updates `once_cell` from 1.20.3 to 1.21.1
- [Changelog](https://github.com/matklad/once_cell/blob/master/CHANGELOG.md)
- [Commits](https://github.com/matklad/once_cell/compare/v1.20.3...v1.21.1)

Updates `proc-macro2` from 1.0.93 to 1.0.94
- [Release notes](https://github.com/dtolnay/proc-macro2/releases)
- [Commits](https://github.com/dtolnay/proc-macro2/compare/1.0.93...1.0.94)

Updates `quote` from 1.0.38 to 1.0.40
- [Release notes](https://github.com/dtolnay/quote/releases)
- [Commits](https://github.com/dtolnay/quote/compare/1.0.38...1.0.40)

Updates `rust-embed-impl` from 8.5.0 to 8.6.0
- [Changelog](https://github.com/pyrossh/rust-embed/blob/master/changelog.md)
- [Commits](https://github.com/pyros2097/rust-embed/commits)

Updates `rust-embed-utils` from 8.5.0 to 8.6.0
- [Changelog](https://github.com/pyrossh/rust-embed/blob/master/changelog.md)
- [Commits](https://github.com/pyros2097/rust-embed/commits)

Updates `rustversion` from 1.0.19 to 1.0.20
- [Release notes](https://github.com/dtolnay/rustversion/releases)
- [Commits](https://github.com/dtolnay/rustversion/compare/1.0.19...1.0.20)

Updates `ryu` from 1.0.19 to 1.0.20
- [Release notes](https://github.com/dtolnay/ryu/releases)
- [Commits](https://github.com/dtolnay/ryu/compare/1.0.19...1.0.20)

Updates `serde` from 1.0.218 to 1.0.219
- [Release notes](https://github.com/serde-rs/serde/releases)
- [Commits](https://github.com/serde-rs/serde/compare/v1.0.218...v1.0.219)

Updates `serde_derive` from 1.0.218 to 1.0.219
- [Release notes](https://github.com/serde-rs/serde/releases)
- [Commits](https://github.com/serde-rs/serde/compare/v1.0.218...v1.0.219)

Updates `syn` from 2.0.98 to 2.0.100
- [Release notes](https://github.com/dtolnay/syn/releases)
- [Commits](https://github.com/dtolnay/syn/compare/2.0.98...2.0.100)

Updates `time` from 0.3.37 to 0.3.41
- [Release notes](https://github.com/time-rs/time/releases)
- [Changelog](https://github.com/time-rs/time/blob/main/CHANGELOG.md)
- [Commits](https://github.com/time-rs/time/compare/v0.3.37...v0.3.41)

Updates `time-core` from 0.1.2 to 0.1.4
- [Release notes](https://github.com/time-rs/time/releases)
- [Changelog](https://github.com/time-rs/time/blob/main/CHANGELOG.md)
- [Commits](https://github.com/time-rs/time/commits)

Updates `tokio` from 1.43.0 to 1.44.1
- [Release notes](https://github.com/tokio-rs/tokio/releases)
- [Commits](https://github.com/tokio-rs/tokio/compare/tokio-1.43.0...tokio-1.44.1)

Updates `unicode-ident` from 1.0.17 to 1.0.18
- [Release notes](https://github.com/dtolnay/unicode-ident/releases)
- [Commits](https://github.com/dtolnay/unicode-ident/compare/1.0.17...1.0.18)

Updates `wasi` from 0.13.3+wasi-0.2.2 to 0.14.2+wasi-0.2.4
- [Commits](https://github.com/bytecodealliance/wasi-rs/compare/0.13.3...0.14.2)

Updates `wit-bindgen-rt` from 0.33.0 to 0.39.0
- [Release notes](https://github.com/bytecodealliance/wit-bindgen/releases)
- [Commits](https://github.com/bytecodealliance/wit-bindgen/compare/v0.33.0...v0.39.0)

---
updated-dependencies:
- dependency-name: anyhow dependency-type: direct:production update-type: version-update:semver-patch dependency-group: crates
- dependency-name: clap dependency-type: direct:production update-type: version-update:semver-patch dependency-group: crates
- dependency-name: zip dependency-type: direct:production update-type: version-update:semver-minor dependency-group: crates
- dependency-name: log dependency-type: direct:production update-type: version-update:semver-patch dependency-group: crates
- dependency-name: env_logger dependency-type: direct:production update-type: version-update:semver-patch dependency-group: crates
- dependency-name: serde_json dependency-type: direct:production update-type: version-update:semver-patch dependency-group: crates
- dependency-name: libc dependency-type: direct:production update-type: version-update:semver-patch dependency-group: crates
- dependency-name: rust-embed dependency-type: direct:production update-type: version-update:semver-minor dependency-group: crates
- dependency-name: sha256 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: crates
- dependency-name: tempfile dependency-type: direct:production update-type: version-update:semver-minor dependency-group: crates
- dependency-name: chrono dependency-type: direct:production update-type: version-update:semver-patch dependency-group: crates
- dependency-name: android_logger dependency-type: direct:production update-type: version-update:semver-minor dependency-group: crates
- dependency-name: android_log-sys dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: async-trait dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: bytes dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: cc dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: clap_builder dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: clap_derive dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: either dependency-type: indirect update-type: version-update:semver-minor dependency-group: crates
- dependency-name: getrandom dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: iana-time-zone dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: indexmap dependency-type: indirect update-type: version-update:semver-minor dependency-group: crates
- dependency-name: itoa dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: once_cell dependency-type: indirect update-type: version-update:semver-minor dependency-group: crates
- dependency-name: proc-macro2 dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: quote dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: rust-embed-impl dependency-type: indirect update-type: version-update:semver-minor dependency-group: crates
- dependency-name: rust-embed-utils dependency-type: indirect update-type: version-update:semver-minor dependency-group: crates
- dependency-name: rustversion dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: ryu dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: serde dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: serde_derive dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: syn dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: time dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: time-core dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: tokio dependency-type: indirect update-type: version-update:semver-minor dependency-group: crates
- dependency-name: unicode-ident dependency-type: indirect update-type: version-update:semver-patch dependency-group: crates
- dependency-name: wasi dependency-type: indirect update-type: version-update:semver-minor dependency-group: crates
- dependency-name: wit-bindgen-rt dependency-type: indirect update-type: version-update:semver-minor dependency-group: crates ...